### PR TITLE
chown files to node to fix permissions in Dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,9 @@ USER node
 RUN mkdir -p /home/node/codenames
 WORKDIR /home/node/codenames
 
-ADD * ./
-ADD server/ ./server/
-ADD public/ ./public/
+COPY --chown=node * ./
+COPY --chown=node server/ ./server/
+COPY --chown=node public/ ./public/
 
 RUN npm install
 


### PR DESCRIPTION
I had trouble using this due to the `node` user not having permissions on the files. Adding the `--chown=node` flag fixed it.

Also, according to [this StackOverflow answer](https://stackoverflow.com/a/24958548), `ADD` does extra magic over `COPY`, so it's recommended to use `COPY` when you don't need that magic.